### PR TITLE
Add get injections for php

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -47,6 +47,8 @@ Examples:
 		var injectables []scanutil.InjectionObject
 		fmt.Printf("Running Error based scan...\n")
 		injectables = append(injectables, scanners.ErrorBasedInjectionTest(attackObj)...)
+		fmt.Printf("Running GET parameter scan...\n")
+		injectables = append(injectables, scanners.GetInjectionTest(attackObj)...)
 		fmt.Printf("Running Boolean based scan...\n")
 		injectables = append(injectables, scanners.BlindBooleanInjectionTest(attackObj)...)
 		fmt.Printf("Running Timing based scan...\n")

--- a/data/injectionData.go
+++ b/data/injectionData.go
@@ -38,7 +38,7 @@ var MongoSpecialCharacters = []string{"'", "\"", "$", ".", ">", "[", "]"}
 var MongoSpecialKeyCharacters = []string{"[$]"}
 var MongoJSONErrorAttacks = []string{`{"foo": 1}`}
 var MongoPrefixes = []string{"'", "\""}
-var MongoGetInjection = []string{"[$nin][]", "[$ne]", "[$gt]", "[$lt]"}	//Not currently used, but might be usable later
+var MongoGetInjection = []string{"[$nin][]", "[$ne]", "[$gt]", "[$lt]"}
 var ObjectPrefixes = []string{""}
 
 /*

--- a/scanners/get_injection_scanner.go
+++ b/scanners/get_injection_scanner.go
@@ -1,0 +1,185 @@
+/*
+Copyright © 2019 Charlie Belmer <Charlie.Belmer@protonmail.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package scanners
+
+import (
+    "github.com/Charlie-belmer/nosqli/data"
+    "github.com/Charlie-belmer/nosqli/scanutil"
+    "fmt"
+)
+
+/**
+Attempt to inject control characters into get parameters, searching for different values
+**/
+func GetInjectionTest(att scanutil.AttackObject) []scanutil.InjectionObject {
+    var injectables []scanutil.InjectionObject
+    injectables = append(injectables, InjectMongoCharacters(att)...)
+    return injectables
+}
+
+
+/*
+ * Check to see if a list of injectables already contains a given paramter
+ */
+func injectablesContainsParam(injectables []scanutil.InjectionObject, param string) bool {
+    for _, i := range injectables {
+        if i.InjectableParam == param {
+            return true
+        }
+    }
+    return false
+}
+
+/*
+ * Check to see if a list of injectables already contains all the given paramtera
+ */
+func injectablesContainsParams(injectables []scanutil.InjectionObject, params []string) bool {
+    for _, p := range params {
+        if injectablesContainsParam(injectables, p) {
+            return true
+        }
+    }
+    return false
+}
+
+func paramsFromTransform(combination []map[string]string) []string {
+    params := make([]string, len(combination))
+    for i, valmap := range(combination) {
+        params[i] = valmap["oldkey"]
+    }
+    return params
+}
+
+/**
+ *  Try to test various get parameter injections, searching for different results.
+ *  For instance param=basic might return a different page than param[$lt] basic or 
+ *  param[$nin]=basic. 
+ *  If it works with one parameter, it likely works with all GET injections.
+ */
+func InjectMongoCharacters(att scanutil.AttackObject) []scanutil.InjectionObject {
+    baseline := att.Copy()
+    baselineRes, err := baseline.Send()
+    if err != nil {
+        fmt.Println(err)
+        return nil
+    }
+
+    truthyValues := [][]string{ {"[$ne]", ""}, {"[$ne]", "a"} }
+
+    var injectables []scanutil.InjectionObject
+/*
+    combinations := scanutil.GetTransformedValues(
+                        att.QueryParams(),
+                        func(s string) string { return s + injection },
+                        func(_ string) string { return injectedValue },
+                        true,
+                        true,
+                    )
+*/
+    keys := scanutil.Keys(att.QueryParams())
+    for combo := range scanutil.StringCombinations(keys) {
+        for _, injection := range data.MongoGetInjection {
+            for _, p := range combo {
+                // We have to run the injections once for each truthy value
+                for _, truthyInjection := range truthyValues {
+                    if injectablesContainsParam(injectables, p) { continue } // don't check params we already caught
+
+                    injectionObj := att.Copy()
+                    // Go through all other keys in combo, setting to truthy
+                    for _, p2 := range combo {
+                        if p2 == p {continue}
+                        injectionObj.ReplaceQueryParam(p2, p2 + truthyInjection[0], truthyInjection[1])
+                    }
+                    for _, injectedValue := range append([]string{"", "a", "z", "0", "9"}, att.QueryParams()[p]) {
+                        injectionObj.ReplaceQueryParam(p, p + injection, injectedValue)
+                        res, _ := injectionObj.Send()
+                        if !baselineRes.ContentEquals(res) {
+                            var injectable = scanutil.InjectionObject{
+                                Type:            scanutil.GetParam,
+                                AttackObject:    injectionObj,
+                                InjectableParam: p,
+                                InjectedParam:   p + injection,
+                                InjectedValue:   injectedValue,
+                            }
+                            injectables = append(injectables, injectable)
+                            // don't keep searching for more injections on this param since we found one:
+                            break
+                        }
+                        injectionObj.ReplaceQueryParam(p + injection, p, injectedValue)
+                    }
+                }
+            }
+        }
+    }
+    return injectables
+}
+
+
+// Try making the generation generic
+/*
+func InjectMongoCharactersTrial(att scanutil.AttackObject) []scanutil.InjectionObject {
+    baseline := att.Copy()
+    baselineRes, err := baseline.Send()
+    if err != nil {
+        fmt.Println(err)
+        return nil
+    }
+
+    var injectables []scanutil.InjectionObject
+
+    combinations := scanutil.GetTransformedValues(
+                        att.QueryParams(),
+                        func(s string) string { return s + injection },
+                        func(_ string) string { return injectedValue },
+                        true,
+                        true,
+                    )
+    for _, combo := range(combinations) {
+        params := paramsFromTransform(combo)
+        if injectablesContainsParams(injectables, params) {
+            continue
+        }
+        for _, injection := range data.MongoGetInjection {
+            for _, injectedValue := range append([]string{"", "a", "z", "0", "9"}, scanutil.Values(params)...) {
+                injectionObj := att.Copy()
+                injectedParams := ""
+                injectedParamNew := ""
+                for _, valmap := range(combo) {
+                    injectionObj.ReplaceQueryParam(valmap["oldkey"], valmap["newkey"], valmap["newvalue"])
+                    injectedParams += valmap["oldkey"] + ","
+                    injectedParamNew += valmap["newkey"] + ","
+                }
+                res, _ := injectionObj.Send()
+                if !baselineRes.ContentEquals(res) {
+                    for _, p := range params {
+                        // add one for each param
+                        var injectable = scanutil.InjectionObject{
+                            Type:            scanutil.GetParam,
+                            AttackObject:    injectionObj,
+                            InjectableParam: p,
+                            InjectedParam:   injectedParamNew,
+                            InjectedValue:   injectedValue,
+                        }
+                        injectables = append(injectables, injectable)
+                    }
+                }
+            }
+        }
+    }
+    return injectables
+}
+*/

--- a/scanners/get_injection_scanner_test.go
+++ b/scanners/get_injection_scanner_test.go
@@ -1,0 +1,144 @@
+package scanners_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"github.com/Charlie-belmer/nosqli/scanners"
+	"fmt"
+)
+
+/***********
+ * Tests
+***********/
+var sentGETInjectionValuesTest = []struct {
+	name string
+	paramname  string
+	paramvalue string
+	expectedInjection string
+}{
+	{"Baseline request", "param", "value", "param[$ne]=value"},
+	{"Added some value", "param", "value", "param[$gt]=a"},
+}
+func TestGetInjectionValues(t *testing.T) {
+	for _, test := range sentGETInjectionValuesTest {
+		t.Run(test.name, func(t *testing.T) {
+			seen := false
+	    	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	    		w.Header().Set("Content-Type", "application/json")
+		    	u, _ := url.QueryUnescape(r.URL.RawQuery)
+		    	fmt.Printf("Saw this query: %+v\n", u)
+		    	if u == test.expectedInjection {
+		    		seen = true
+		    	}
+		        
+		    }))
+		    defer ts.Close()
+
+		    url := ts.URL + "?" + test.paramname + "=" + test.paramvalue
+			att := setup(t, url, "")
+			scanners.GetInjectionTest(att)
+
+			if !seen{
+				t.Errorf("Missing injection string: %+v\n", test.expectedInjection)
+			}
+			
+		})
+	}
+}
+
+/***********
+ * Tests
+***********/
+var sentMultipleGETInjectionValuesTest = []struct {
+	name string
+	param1name  string
+	param1value string
+	param2name  string
+	param2value string
+	expectedInjection string
+}{
+	{"Baseline request", "param1", "value1", "param2", "value2", "param1[$ne]=&param2[$gt]=value2"},
+	{"Baseline request", "param1", "value1", "param2", "value2", "param1[$ne]=a&param2[$gt]=value2"},
+	{"Baseline request", "param1", "value1", "param2", "value2", "param1[$ne]=value1&param2[$ne]="},
+	{"Baseline request", "param1", "value1", "param2", "value2", "param1[$ne]=value1&param2[$ne]=a"},
+	{"Added some value", "param1", "value1", "param2", "value2", "param1[$gt]=&param2[$ne]="},
+}
+func TestGetInjectionMultipleValues(t *testing.T) {
+	for _, test := range sentMultipleGETInjectionValuesTest {
+		t.Run(test.name, func(t *testing.T) {
+			seen := false
+	    	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	    		w.Header().Set("Content-Type", "application/json")
+		    	u, _ := url.QueryUnescape(r.URL.RawQuery)
+		    	fmt.Printf("Saw this query: %+v\n", u)
+		    	if u == test.expectedInjection {
+		    		seen = true
+		    	}
+		        
+		    }))
+		    defer ts.Close()
+
+		    url := ts.URL + "?" + test.param1name + "=" + test.param1value + "&" + test.param2name + "=" + test.param2value
+			att := setup(t, url, "")
+			scanners.GetInjectionTest(att)
+
+			if !seen{
+				t.Errorf("Missing injection string: %+v\n", test.expectedInjection)
+			}
+			
+		})
+	}
+}
+
+
+/***********
+ * Integration Tests
+ * 	Depends on a local vulnerable node app for testing: https://github.com/Charlie-belmer/vulnerable-node-app
+***********/
+
+var GETInjectionIntegrationTest = []struct {
+	name string
+	url  string
+	injectionsFound int
+	injectableParams []string
+}{
+	{"Correct user param, correct type param", "http://localhost:8081/user_lookup.php?type=user&username=joe", 2, []string{"type", "username"}},
+	{"Correct user param, Incorrect type param, ", "http://localhost:8081/user_lookup.php?type=a&username=joe", 2, []string{"type", "username"}},
+	{"Correct user param, Empty type param", "http://localhost:8081/user_lookup.php?type=&username=joe", 2, []string{"type", "username"}},
+	{"Correct user param, admin type param", "http://localhost:8081/user_lookup.php?type=admin&username=joe", 2, []string{"type", "username"}},
+	{"Incorrect user param, correct type param", "http://localhost:8081/user_lookup.php?type=user&username=a", 2, []string{"type", "username"}},
+	{"Incorrect user param, Incorrect type param", "http://localhost:8081/user_lookup.php?type=a&username=a", 2, []string{"type", "username"}},
+	{"Incorrect user param, empty type param", "http://localhost:8081/user_lookup.php?type=&username=a", 2, []string{"type", "username"}},
+	{"Incorrect user param, admin type param", "http://localhost:8081/user_lookup.php?type=admin&username=a", 2, []string{"type", "username"}},
+	{"Empty user param, correct type param", "http://localhost:8081/user_lookup.php?type=user&username=", 2, []string{"type", "username"}},
+	{"Empty user param, incorrect type param", "http://localhost:8081/user_lookup.php?type=a&username=", 2, []string{"type", "username"}},
+	{"Empty user param, empty type param", "http://localhost:8081/user_lookup.php?type=&username=", 2, []string{"type", "username"}},
+	{"Empty user param, admin type param", "http://localhost:8081/user_lookup.php?type=admin&username=", 2, []string{"type", "username"}},
+}
+func TestGETInjectionIntegration(t *testing.T) {
+	if *runIntegrations {
+		for _, test := range GETInjectionIntegrationTest {
+			t.Run(test.name, func(t *testing.T) {
+				att := setup(t, test.url, "")
+				injectables := scanners.GetInjectionTest(att)
+
+				if len(injectables) != test.injectionsFound {
+					t.Errorf("%+v:\nMismatch in findings length with url %+v\nGot: %+v findings. \nExpected: %+v\nGot: %#v\n\n", test.name, test.url, len(injectables), test.injectionsFound, injectables)
+				}
+				for _, param := range test.injectableParams {
+					found_param := false
+					for _, i := range injectables {
+						if i.InjectableParam == param {
+							found_param = true
+						}
+					}
+					if ! found_param {
+						t.Errorf("%+v:\n Missed Injectable parameter %+v with url %+v\nGot: %+v\n\n", test.name, param, test.url, injectables)
+					}
+				}
+			})
+		}
+	}
+}

--- a/scanutil/InjectionObject.go
+++ b/scanutil/InjectionObject.go
@@ -28,6 +28,7 @@ const (
 	Blind = InjectionType(iota)
 	Timed
 	Error
+	GetParam
 )
 
 func (it InjectionType) String() string {
@@ -38,6 +39,8 @@ func (it InjectionType) String() string {
 		return "Timing based NoSQL Injection"
 	case Error:
 		return "Error based NoSQL Injection"
+	case GetParam:
+		return "Get Parameter NoSQL Injection"
 	}
 	return ""
 }
@@ -57,6 +60,8 @@ type InjectionObject struct {
 	InjectableParam string
 	InjectedParam   string
 	InjectedValue   string
+	Prefix			string
+	Suffix 			string
 }
 
 func (i *InjectionObject) Print() {

--- a/scanutil/util_test.go
+++ b/scanutil/util_test.go
@@ -32,6 +32,7 @@ func cmpSlice(s1, s2 []string) bool {
 	return false
 }
 
+
 /**
  * Deeply sort a list of list of strings
  */
@@ -44,10 +45,19 @@ func sortEmbedded(s [][]string) {
 	sort.SliceStable(s, func(i, j int) bool { return cmpSlice(s[i],s[j]) })
 }
 
+func sortDeepMap(m [][]map[string]string) {
+	for _, sl := range m {
+		sort.SliceStable(sl, func(i,j int) bool { return sl[i]["newkey"] < sl[j]["newkey"] })
+	}
+
+	sort.SliceStable(m, func(i,j int) bool { return m[i][0]["newkey"] < m[j][0]["newkey"] })
+}
+
+
 /**
  *	Determine all combinations are successfully generated.
  */
- var combinationTests = []struct {
+var combinationTests = []struct {
  	name string
 	input []scanutil.BodyItem
 	output  [][]scanutil.BodyItem
@@ -77,7 +87,8 @@ func TestCombinations(t *testing.T) {
 	}
 }
 
- var stringCombinationTests = []struct {
+
+var stringCombinationTests = []struct {
  	name string
 	input []string
 	output  [][]string
@@ -106,6 +117,136 @@ func TestStringCombinations(t *testing.T) {
 			eq := reflect.DeepEqual(result, test.output)
 			if !eq {
 				t.Errorf("Combinations function did not return the expected combinations.\nExpected: %+v\nActual:   %+v\n", test.output, result)
+			}
+		})
+	}
+}
+
+
+var mapKeysTests = []struct {
+ 	name 	string
+	input 	map[string]string
+	output  []string
+}{
+	{	"simple key,value pairs",
+		map[string]string{"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"}, 
+		[]string{"k1", "k2", "k3", "k4"},
+	},
+	{ "Single Element", map[string]string{"k1": "v1"}, []string{"k1"},},
+}
+func TestMapKeyExtraction(t *testing.T) {
+	for _, test := range mapKeysTests {
+		t.Run(test.name, func(t *testing.T) {
+			result := scanutil.Keys(test.input)
+			sort.SliceStable(result, func(i, j int) bool { return result[i] < result[j] })
+			sort.SliceStable(test.output, func(i, j int) bool { return test.output[i] < test.output[j] })
+			eq := reflect.DeepEqual(result, test.output)
+			if !eq {
+				t.Errorf("Keys incorrectly extracted.\nExpected: %+v\nActual:   %+v\n", test.output, result)
+			}
+		})
+	}
+}
+
+var mapValuesTests = []struct {
+ 	name 	string
+	input 	map[string]string
+	output  []string
+}{
+	{	"simple key,value pairs",
+		map[string]string{"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"}, 
+		[]string{"v1", "v2", "v3", "v4"},
+	},
+	{ "Single Element", map[string]string{"k1": "v1"}, []string{"v1"},},
+}
+func TestMapValueExtraction(t *testing.T) {
+	for _, test := range mapValuesTests {
+		t.Run(test.name, func(t *testing.T) {
+			result := scanutil.Values(test.input)
+			sort.SliceStable(result, func(i, j int) bool { return result[i] < result[j] })
+			sort.SliceStable(test.output, func(i, j int) bool { return test.output[i] < test.output[j] })
+			eq := reflect.DeepEqual(result, test.output)
+			if !eq {
+				t.Errorf("Values incorrectly extracted.\nExpected: %+v\nActual:   %+v\n", test.output, result)
+			}
+		})
+	}
+}
+
+var getTransformedValuesTests = []struct {
+ 	name 	string
+ 	kvList map[string]string
+ 	keyTransform func(string) string
+ 	valTransform func(string) string
+ 	shouldTransformKey bool
+ 	shouldTransformValue bool
+	output  [][]map[string]string
+}{
+	{	"Tansform single value",
+		map[string]string{"k1": "v1"}, 
+		func(s string) string { return s + "akey" },
+		func(s string) string { return s + "avalue" },
+		true,
+		true,
+		[][]map[string]string { 
+			[]map[string]string{
+				map[string]string {"newkey":"k1akey", "newvalue":"v1avalue", "oldkey":"k1", "oldvalue":"v1"},
+			},
+		},
+	},
+	{	"Tansform single value, but not the key",
+		map[string]string{"k1": "v1"}, 
+		func(s string) string { return s + "akey" },
+		func(s string) string { return s + "avalue" },
+		false,
+		true,
+		[][]map[string]string {
+			[]map[string]string{
+				map[string]string {"newkey":"k1", "newvalue":"v1avalue", "oldkey":"k1", "oldvalue":"v1"},
+			},
+		},
+	},
+	{	"Tansform single value, but not the value",
+		map[string]string{"k1": "v1"}, 
+		func(s string) string { return s + "akey" },
+		func(s string) string { return s + "avalue" },
+		true,
+		false,
+		[][]map[string]string {
+			[]map[string]string{
+				map[string]string {"newkey":"k1akey", "newvalue":"v1", "oldkey":"k1", "oldvalue":"v1"},
+			},
+		},
+	},
+	{	"Tansform two values",
+		map[string]string{"k1": "v1", "k2": "v2"}, 
+		func(s string) string { return s + "akey" },
+		func(s string) string { return s + "avalue" },
+		true,
+		true,
+		[][]map[string]string {
+			[]map[string]string{
+				map[string]string {"newkey":"k1akey", "newvalue":"v1avalue", "oldkey":"k1", "oldvalue":"v1"},
+			},
+			[]map[string]string{
+				map[string]string {"newkey":"k2akey", "newvalue":"v2avalue", "oldkey":"k2", "oldvalue":"v2"},
+			},
+			[]map[string]string{
+				map[string]string {"newkey":"k1akey", "newvalue":"v1avalue", "oldkey":"k1", "oldvalue":"v1"},
+				map[string]string {"newkey":"k2akey", "newvalue":"v2avalue", "oldkey":"k2", "oldvalue":"v2"},
+			},
+		},
+	},
+}
+func TestGetTransformedValues(t *testing.T) {
+	for _, test := range getTransformedValuesTests {
+		t.Run(test.name, func(t *testing.T) {
+			result := scanutil.GetTransformedValues(test.kvList, test.keyTransform, test.valTransform, test.shouldTransformKey, test.shouldTransformValue)
+			sortDeepMap(result)
+			sortDeepMap(test.output)
+			eq := reflect.DeepEqual(result, test.output)
+			if !eq {
+				t.Errorf("Values transformed incorrectly.\nExpected: %+v\nActual:   %+v\n", test.output, result)
 			}
 		})
 	}


### PR DESCRIPTION
Adds tests for various GET injections for PHP sites.

This tests for parameter modification, where a site has GET parameters like `?user=me` and attempts to check for injections such as `?user[$gt]=a`