### PR TITLE
added close for filesystem object

### DIFF
--- a/scanutil/attackObject.go
+++ b/scanutil/attackObject.go
@@ -98,6 +98,8 @@ func parseRequest(file string, options ScanOptions) AttackObject {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer fh.Close()
+
 	data := bufio.NewReader(fh)
 	obj.Request, err = http.ReadRequest(data)
 	if err != nil {


### PR DESCRIPTION
Not sure if this will address #9, but I noticed that the `Close()` method was missing on this filesystem handler!

The GC would eventually close them at some point, but it might not free up the file descriptors before the scan is complete.